### PR TITLE
add cas v2 authentication

### DIFF
--- a/python/lib/user/user.py
+++ b/python/lib/user/user.py
@@ -149,3 +149,22 @@ class User():
         data = {"ticket": st, "login": username}
 
         return data
+
+    @staticmethod
+    def validate_auth_ticket(ticket):
+        """
+        validation of the ticket from the cas in order to authenticate the user
+        """
+
+        headerscas = {
+            'Content-type': 'application/x-www-form-urlencoded',
+            'Accept': 'text/plain',
+            'User-Agent': 'python'
+        }
+
+        response = requests.get(f"{_CAS_URL}{ticket}", headers=headerscas)
+
+        if response.status_code  != 200:
+            return False
+
+        return True

--- a/python/lib/webapis/login.py
+++ b/python/lib/webapis/login.py
@@ -58,6 +58,44 @@ def login_cas():
         info_user["token"] = user_auth_inst["token"]
         return info_user
 
+@post('/login_v2')
+def login_v2():
+    try:
+        data = json.loads(request.body.read())
+        if data is None or not data.get('username') or not data.get('ticket'):
+            raise ValueError
+
+        validation = User.validate_auth_ticket(data["ticket"])
+
+        if not validation:
+            raise ValueError
+
+        user = User.build_user_from_login(data["username"])
+
+        user_auth = ConnexionHandler.build_handler(login=data['username'])
+
+        user_auth_inst = user_auth.handle_connexion()
+        
+        info_user = user.get_user_info()
+
+        if info_user is None and user_auth_inst["token"]:
+            user_return = {
+                "login": user_log.get("login"),
+                "token": user_auth_inst["token"]
+            }
+            return user_return
+        else:
+            info_user["token"] = user_auth_inst["token"]
+            return info_user
+
+    except ValueError:
+        response.status = 400
+        return json.dumps({"error": "Wrong authentication"})
+
+    except Exception as e:
+        response.status = 400
+        return  json.dumps({"error": "Bad request"})
+
 @get('/logout')
 @authenticate
 def logout():


### PR DESCRIPTION
/!\ A LIRE /!\

J'ai tenté de faire quelque chose qui soit bon pour le SiMDE sans pour autant tout péter ce qu'on avait fait. 
l'idée est de ne jamais avoir à utiliser le password et donc de l'externaliser. 

j'ai donc créé la méthode validate_auth_ticket() qui prend en parametre un ticket et qui va aller checker sa validation auprès du cas (méthode get en rest) 
si la validation est bonne ca envoie une 200 sinon une 404. 

pour ce qui est de la route /login_v2 
je prend en parametre un username et un ticket, je check le ticket et apres je fais EXACTEMENT PAREIL que ce qui est fait actuellement (création du token etc etc)



Donc dans lidée ( je l'ai pas encore codé mais ca vient ce weekend promis) avec le front: 

le mec entre login / password
ca envoie une requete au CAS dont on attend la réponse (tout a en front donc) 
une fois le ticket obtenu on envoie au back, qui va s'assurer que le ticket est valide avant de créer un token interne. 

VOILAAAAAAA